### PR TITLE
Restore no_std throughout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,11 +8,20 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.63.0 # MSRV
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
 
     steps:
     - uses: actions/checkout@v3

--- a/cbor_derive/Cargo.toml
+++ b/cbor_derive/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = "1"
 quote = "1"
 syn = { version = "1.0.58", features = ["extra-traits"] }
 ciborium = "0.2.0"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 hex-literal = "0.3.4"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,13 +15,13 @@ rust-version = "1.63"
 [dependencies]
 cbor_derive = { version = "0.1.0", path = "../cbor_derive" }
 ciborium = "0.2.0"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 hex-literal = "0.3.4"
 serde_bytes = "0.11"
 serde_repr = "0.1.9"
 num_enum = "0.5.7"
-serde-enum-str = "0.2.5"
+#serde-enum-str = {version = "0.2.5", default-features = false}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/src/arrays.rs
+++ b/common/src/arrays.rs
@@ -8,6 +8,8 @@ use serde::{__private::size_hint, de::Error, de::Visitor};
 
 use alloc::{vec, vec::Vec};
 
+use alloc::format;
+use alloc::string::{String, ToString};
 use cbor_derive::StructToArray;
 
 /// The `hash-entry` type is defined in [CoRIM Section 1.3.8].

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 pub mod arrays;

--- a/common/src/tuple.rs
+++ b/common/src/tuple.rs
@@ -1,7 +1,8 @@
 //! General-purpose Tuple and TupleCbor types
 
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
 use ciborium::value::{Integer, Value};
 use core::{fmt, marker::PhantomData};
 use serde::de::Error;

--- a/common/src/tuple_map.rs
+++ b/common/src/tuple_map.rs
@@ -1,7 +1,8 @@
 //! General-purpose TupleMap and TupleMapCbor types
 
 use crate::tuple::*;
-use alloc::vec::Vec;
+use alloc::string::{String, ToString};
+use alloc::{vec, vec::Vec};
 use ciborium::value::Value;
 use core::{fmt, marker::PhantomData};
 use serde::de::MapAccess;

--- a/corim/Cargo.toml
+++ b/corim/Cargo.toml
@@ -21,10 +21,10 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_bytes = "0.11"
 serde_json = "1.0.89"
 serde_repr = "0.1.9"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 hex-literal = "0.3.4"
 num_enum = "0.5.7"
-serde-enum-str = "0.2.5"
+#serde-enum-str = {version = "0.2.5", default-features = false}
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/corim/src/arrays.rs
+++ b/corim/src/arrays.rs
@@ -10,6 +10,8 @@ use alloc::{vec, vec::Vec};
 
 use crate::choices::*;
 use crate::maps::*;
+use alloc::format;
+use alloc::string::{String, ToString};
 use cbor_derive::StructToArray;
 use common::TextOrBinary;
 

--- a/corim/src/choices.rs
+++ b/corim/src/choices.rs
@@ -1,5 +1,7 @@
 //! Choice-based structs from the Concise Reference Integrity Manifest (CoRIM) spec
 
+use alloc::format;
+use alloc::string::{String, ToString};
 use ciborium::value::{Integer, Value};
 use common::*;
 use serde::__private::de::Content;
@@ -7,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 
-use alloc::string::{String, ToString};
 use ciborium::tag::Required;
 
 use crate::maps::*;
@@ -487,14 +488,7 @@ impl<'de> serde::Deserialize<'de> for CorimIdTypeChoice {
 /// ```
 ///
 /// [CoRIM Section 3.1.2]: https://datatracker.ietf.org/doc/html/draft-birkholz-rats-corim-03#section-3.1.2
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    serde_enum_str::Deserialize_enum_str,
-    serde_enum_str::Serialize_enum_str,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum CorimRoleTypeChoice {
@@ -504,7 +498,6 @@ pub enum CorimRoleTypeChoice {
     Creator,
     #[serde(rename = "maintainer")]
     Maintainer,
-    #[serde(other)]
     other(String),
 }
 

--- a/corim/src/lib.rs
+++ b/corim/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![allow(clippy::derive_partial_eq_without_eq)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/corim/src/maps.rs
+++ b/corim/src/maps.rs
@@ -1,6 +1,7 @@
 //! Map-based structs from the Concise Reference Integrity Manifest (CoRIM) spec
 
 use alloc::collections::BTreeMap;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 use ciborium::value::Integer;

--- a/coswid/Cargo.toml
+++ b/coswid/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_bytes = "0.11"
 serde_json = "1.0.89"
 serde_repr = "0.1.9"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 hex-literal = "0.3.4"
 num_enum = "0.5.7"
 

--- a/coswid/src/choices.rs
+++ b/coswid/src/choices.rs
@@ -3,7 +3,8 @@
 use ciborium::value::Value;
 use serde::{Deserialize, Serialize};
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use crate::maps::{EvidenceEntry, PayloadEntry};
 use common::IntType;

--- a/coswid/src/lib.rs
+++ b/coswid/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
-//#![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![allow(clippy::derive_partial_eq_without_eq)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 pub mod arrays;

--- a/coswid/src/maps.rs
+++ b/coswid/src/maps.rs
@@ -10,6 +10,7 @@ use serde::{
 
 //use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 

--- a/cots/Cargo.toml
+++ b/cots/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_bytes = "0.11"
 serde_json = "1.0.89"
 serde_repr = "0.1.9"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 hex-literal = "0.3.4"
 num_enum = "0.5.7"
 

--- a/cots/src/arrays.rs
+++ b/cots/src/arrays.rs
@@ -1,4 +1,6 @@
 //! Array-based structs from the Concise Trust Anchor Store (CoTS) spec
+use alloc::format;
+use alloc::string::{String, ToString};
 use ciborium::{cbor, value::Value};
 use core::{fmt, marker::PhantomData};
 use serde::{Deserialize, Serialize};

--- a/cots/src/choices.rs
+++ b/cots/src/choices.rs
@@ -3,7 +3,7 @@
 use ciborium::value::Value;
 use serde::{Deserialize, Serialize};
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
 
 use num_enum::TryFromPrimitive;
 use serde_repr::Deserialize_repr;

--- a/cots/src/lib.rs
+++ b/cots/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![allow(clippy::derive_partial_eq_without_eq)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 // pkix-cert-data = bstr

--- a/cots/src/maps.rs
+++ b/cots/src/maps.rs
@@ -9,6 +9,7 @@ use serde::{
 };
 
 use alloc::collections::BTreeMap;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 

--- a/cots/tests/maps.rs
+++ b/cots/tests/maps.rs
@@ -70,10 +70,7 @@ fn concise_ta_store_test() {
 
 #[test]
 fn cots_test() {
-    let expected = read_cbor(&Some(
-        "./tests/examples/cots_trunc.cbor"
-            .to_string(),
-    ));
+    let expected = read_cbor(&Some("./tests/examples/cots_trunc.cbor".to_string()));
 
     let csc_d: ConciseTaStoresCbor = from_reader(expected.clone().as_slice()).unwrap();
     //println!("Decoded ConciseMidTag: {:?}", comid_d);

--- a/eat/Cargo.toml
+++ b/eat/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 serde_bytes = "0.11"
 serde_json = "1.0.89"
 serde_repr = "0.1.9"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 hex-literal = "0.3.4"
 num_enum = "0.5.7"
 

--- a/eat/src/arrays.rs
+++ b/eat/src/arrays.rs
@@ -5,6 +5,7 @@ use core::{fmt, marker::PhantomData};
 use serde::{Deserialize, Serialize};
 use serde::{__private::size_hint, de::Error, de::Visitor};
 
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 use serde::ser::Error as OtherError;

--- a/eat/src/choices.rs
+++ b/eat/src/choices.rs
@@ -3,9 +3,11 @@
 use ciborium::value::Value;
 use serde::{Deserialize, Serialize};
 
+use alloc::string::{String, ToString};
 use num_enum::TryFromPrimitive;
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
+
 // BUNDLE-Messages = BUNDLE-Tagged-Message / BUNDLE-Untagged-Message
 
 // CBOR-Nested-Token =

--- a/eat/src/lib.rs
+++ b/eat/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![allow(clippy::derive_partial_eq_without_eq)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 // Submodule = CBOR-Submodule

--- a/eat/src/maps.rs
+++ b/eat/src/maps.rs
@@ -11,6 +11,7 @@ use serde::{
 use crate::arrays::*;
 use crate::choices::*;
 use alloc::collections::BTreeMap;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 use cbor_derive::StructToMap;

--- a/webauthn_asf/Cargo.toml
+++ b/webauthn_asf/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 cbor_derive = { version = "0.1.0", path = "../cbor_derive" }
 common = { version = "0.1.0", path = "../common" }
 ciborium = "0.2.0"
-subtle-encoding = "0.5.1"
+subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 hex-literal = "0.3.4"
 serde_bytes = "0.11"

--- a/webauthn_asf/src/lib.rs
+++ b/webauthn_asf/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
-//#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 


### PR DESCRIPTION
- Import from alloc as needed throughout
- Change import of subtle-encoding to omit default features
- Add thumbv7em-none-eabi and wasm32-unknown-unknown targets to build action
- Drop usage of serde-enum-str, for now at least.